### PR TITLE
feat(core/analyzer): 新增系统浏览器自动检测功能

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # 更新日志
 
+### [v1.5.6] - 2026-04-01
+
+#### ✨ 功能增强
+
+- **新增系统浏览器自动检测** (`core/analyzer`)
+  - 启动时优先检测系统已安装的 Chromium 内核浏览器（Chrome > Edge > Chromium），找到即直接使用，无需下载 Playwright 自带浏览器
+  - 支持 Windows 和 Linux 常见安装路径
+  - 自动获取并展示检测到的浏览器版本信息
+  - `browser_install_status.json` 中 `browser_type` 字段现记录实际使用的浏览器名称
+
+---
+
 ### [v1.5.5] - 2026-04-01
 
 #### ✨ 功能增强

--- a/core/analyzer.py
+++ b/core/analyzer.py
@@ -986,6 +986,91 @@ class WebAnalyzer:
         except Exception as e:
             logger.error(f"保存浏览器安装状态失败: {e}")
 
+    @staticmethod
+    def _detect_system_browser() -> tuple[bool, str, str]:
+        """检测系统已安装的 Chromium 内核浏览器
+
+        检测优先级: Chrome > Edge > Chromium
+        支持 Windows 和 Linux
+
+        Returns:
+            tuple: (是否找到, 浏览器路径, 浏览器名称)
+        """
+        import os
+        import platform
+        import subprocess
+
+        system = platform.system()
+        logger.info("开始检测系统已安装的浏览器...")
+
+        # 定义浏览器检测路径
+        browser_paths = []
+
+        if system == "Windows":
+            local_app_data = os.environ.get("LOCALAPPDATA", "")
+            program_files = os.environ.get("ProgramFiles", r"C:\Program Files")
+            program_files_x86 = os.environ.get(
+                "ProgramFiles(x86)", r"C:\Program Files (x86)"
+            )
+
+            browser_paths = [
+                ("Google Chrome", [
+                    os.path.join(program_files, "Google", "Chrome", "Application", "chrome.exe"),
+                    os.path.join(program_files_x86, "Google", "Chrome", "Application", "chrome.exe"),
+                    os.path.join(local_app_data, "Google", "Chrome", "Application", "chrome.exe"),
+                ]),
+                ("Microsoft Edge", [
+                    os.path.join(program_files_x86, "Microsoft", "Edge", "Application", "msedge.exe"),
+                    os.path.join(program_files, "Microsoft", "Edge", "Application", "msedge.exe"),
+                ]),
+            ]
+        elif system == "Linux":
+            browser_paths = [
+                ("Google Chrome", [
+                    "/usr/bin/google-chrome",
+                    "/usr/bin/google-chrome-stable",
+                ]),
+                ("Microsoft Edge", [
+                    "/usr/bin/microsoft-edge",
+                    "/usr/bin/microsoft-edge-stable",
+                ]),
+                ("Chromium", [
+                    "/usr/bin/chromium",
+                    "/usr/bin/chromium-browser",
+                    "/snap/bin/chromium",
+                ]),
+            ]
+
+        for browser_name, paths in browser_paths:
+            for path in paths:
+                exists = os.path.exists(path)
+                logger.debug(
+                    f"检测 {browser_name}: {path} - {'找到!' if exists else '不存在'}"
+                )
+                if exists:
+                    # 尝试获取浏览器版本
+                    version = ""
+                    try:
+                        result = subprocess.run(
+                            [path, "--version"],
+                            capture_output=True,
+                            text=True,
+                            timeout=5,
+                        )
+                        version = result.stdout.strip()
+                    except Exception as e:
+                        logger.debug(f"获取 {browser_name} 版本失败: {e}")
+
+                    version_info = f" (版本: {version})" if version else ""
+                    logger.info(
+                        f"检测到系统已安装的 {browser_name}: {path}{version_info}"
+                    )
+                    logger.info("将使用系统浏览器，跳过 Playwright 自带浏览器的下载安装")
+                    return True, path, browser_name
+
+        logger.debug("未检测到系统已安装的浏览器，将使用 Playwright 自带浏览器")
+        return False, "", ""
+
     async def _check_browser_installed_async(self) -> tuple[bool, str]:
         """异步检查浏览器是否已安装（智能路径探测版本）
 
@@ -994,6 +1079,12 @@ class WebAnalyzer:
         """
         import os
         from pathlib import Path
+
+        # 优先检测系统已安装的浏览器
+        found, sys_path, sys_name = self._detect_system_browser()
+        if found:
+            self._system_browser_name = sys_name
+            return True, sys_path
 
         from playwright.async_api import async_playwright
 
@@ -1311,10 +1402,12 @@ class WebAnalyzer:
                 if os.path.exists(saved_path):
                     self._detected_browser_path = saved_path
                     logger.debug(f"从持久化记录恢复浏览器路径: {saved_path}")
+                    self._playwright_browser_checked = True
+                    return
                 else:
                     logger.warning(f"保存的浏览器路径不存在: {saved_path}，将重新检测")
-            self._playwright_browser_checked = True
-            return
+                    # 清除失效的安装状态，继续走完整检测流程
+                    self._save_install_status({"installed": False})
 
         # 先检查 playwright 是否已安装
         try:
@@ -1374,13 +1467,15 @@ class WebAnalyzer:
                     logger.info(f"浏览器已安装: {browser_info}")
                     # 保存检测到的浏览器路径供启动时使用
                     self._detected_browser_path = browser_info
+                    # 确定浏览器类型
+                    browser_type = getattr(self, "_system_browser_name", "chromium")
                     # 保存安装状态
                     self._save_install_status(
                         {
                             "installed": True,
                             "install_path": browser_info,
                             "install_time": time.time(),
-                            "browser_type": "chromium",
+                            "browser_type": browser_type,
                         }
                     )
                     self._playwright_browser_checked = True

--- a/core/analyzer.py
+++ b/core/analyzer.py
@@ -987,11 +987,25 @@ class WebAnalyzer:
             logger.error(f"保存浏览器安装状态失败: {e}")
 
     @staticmethod
+    def _which_browser(command: str) -> str | None:
+        """使用系统命令查找浏览器可执行文件路径
+
+        Args:
+            command: 浏览器命令名（如 google-chrome、msedge）
+
+        Returns:
+            找到的路径字符串，未找到返回 None
+        """
+        import shutil
+
+        return shutil.which(command)
+
+    @staticmethod
     def _detect_system_browser() -> tuple[bool, str, str]:
         """检测系统已安装的 Chromium 内核浏览器
 
         检测优先级: Chrome > Edge > Chromium
-        支持 Windows 和 Linux
+        支持 Windows、Linux 和 macOS
 
         Returns:
             tuple: (是否找到, 浏览器路径, 浏览器名称)
@@ -1003,70 +1017,101 @@ class WebAnalyzer:
         system = platform.system()
         logger.info("开始检测系统已安装的浏览器...")
 
-        # 定义浏览器检测路径
-        browser_paths = []
+        # 定义浏览器检测：(名称, 命令名, 固定路径列表)
+        browser_candidates: list[tuple[str, str, list[str]]] = []
 
         if system == "Windows":
-            local_app_data = os.environ.get("LOCALAPPDATA", "")
+            local_app_data = os.environ.get(
+                "LOCALAPPDATA"
+            ) or os.path.join(
+                os.environ.get("USERPROFILE", ""), "AppData", "Local"
+            )
             program_files = os.environ.get("ProgramFiles", r"C:\Program Files")
             program_files_x86 = os.environ.get(
                 "ProgramFiles(x86)", r"C:\Program Files (x86)"
             )
 
-            browser_paths = [
-                ("Google Chrome", [
+            browser_candidates = [
+                ("Google Chrome", "chrome", [
                     os.path.join(program_files, "Google", "Chrome", "Application", "chrome.exe"),
                     os.path.join(program_files_x86, "Google", "Chrome", "Application", "chrome.exe"),
                     os.path.join(local_app_data, "Google", "Chrome", "Application", "chrome.exe"),
                 ]),
-                ("Microsoft Edge", [
+                ("Microsoft Edge", "msedge", [
                     os.path.join(program_files_x86, "Microsoft", "Edge", "Application", "msedge.exe"),
                     os.path.join(program_files, "Microsoft", "Edge", "Application", "msedge.exe"),
                 ]),
             ]
         elif system == "Linux":
-            browser_paths = [
-                ("Google Chrome", [
+            browser_candidates = [
+                ("Google Chrome", "google-chrome", [
                     "/usr/bin/google-chrome",
                     "/usr/bin/google-chrome-stable",
+                    "/opt/google/chrome/google-chrome",
                 ]),
-                ("Microsoft Edge", [
+                ("Microsoft Edge", "microsoft-edge", [
                     "/usr/bin/microsoft-edge",
                     "/usr/bin/microsoft-edge-stable",
                 ]),
-                ("Chromium", [
+                ("Chromium", "chromium", [
                     "/usr/bin/chromium",
                     "/usr/bin/chromium-browser",
                     "/snap/bin/chromium",
                 ]),
             ]
+        elif system == "Darwin":
+            browser_candidates = [
+                ("Google Chrome", "Google Chrome", [
+                    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+                ]),
+                ("Microsoft Edge", "Microsoft Edge", [
+                    "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+                ]),
+                ("Chromium", "Chromium", [
+                    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+                ]),
+            ]
 
-        for browser_name, paths in browser_paths:
-            for path in paths:
-                exists = os.path.exists(path)
-                logger.debug(
-                    f"检测 {browser_name}: {path} - {'找到!' if exists else '不存在'}"
-                )
-                if exists:
-                    # 尝试获取浏览器版本
-                    version = ""
-                    try:
-                        result = subprocess.run(
-                            [path, "--version"],
-                            capture_output=True,
-                            text=True,
-                            timeout=5,
-                        )
-                        version = result.stdout.strip()
-                    except Exception as e:
-                        logger.debug(f"获取 {browser_name} 版本失败: {e}")
-
-                    version_info = f" (版本: {version})" if version else ""
-                    logger.info(
-                        f"检测到系统已安装的 {browser_name}: {path}{version_info}"
+        for browser_name, command, paths in browser_candidates:
+            # 先用 which/shutil 检查 PATH 中是否存在
+            which_path = WebAnalyzer._which_browser(command)
+            if which_path:
+                logger.debug(f"通过 PATH 检测到 {browser_name}: {which_path}")
+                found_path = which_path
+            else:
+                # 回退到固定路径检测
+                found_path = ""
+                for path in paths:
+                    exists = os.path.exists(path)
+                    logger.debug(
+                        f"检测 {browser_name}: {path} - {'找到!' if exists else '不存在'}"
                     )
-                    logger.info("将使用系统浏览器，跳过 Playwright 自带浏览器的下载安装")
-                    return True, path, browser_name
+                    if exists:
+                        found_path = path
+                        break
+
+            if not found_path:
+                continue
+
+            # 尝试获取浏览器版本
+            version = ""
+            try:
+                result = subprocess.run(
+                    [found_path, "--version"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                version = result.stdout.strip()
+            except Exception as e:
+                logger.debug(f"获取 {browser_name} 版本失败: {e}")
+
+            version_info = f" (版本: {version})" if version else ""
+            logger.info(
+                f"检测到系统已安装的 {browser_name}: {found_path}{version_info}"
+            )
+            logger.info("将使用系统浏览器，跳过 Playwright 自带浏览器的下载安装")
+            return True, found_path, browser_name
 
         logger.debug("未检测到系统已安装的浏览器，将使用 Playwright 自带浏览器")
         return False, "", ""
@@ -1467,8 +1512,14 @@ class WebAnalyzer:
                     logger.info(f"浏览器已安装: {browser_info}")
                     # 保存检测到的浏览器路径供启动时使用
                     self._detected_browser_path = browser_info
-                    # 确定浏览器类型
-                    browser_type = getattr(self, "_system_browser_name", "chromium")
+                    # 确定浏览器类型（映射为规范标识）
+                    system_browser_name = getattr(self, "_system_browser_name", "")
+                    browser_type_map = {
+                        "Google Chrome": "chrome",
+                        "Microsoft Edge": "edge",
+                        "Chromium": "chromium",
+                    }
+                    browser_type = browser_type_map.get(system_browser_name, "chromium")
                     # 保存安装状态
                     self._save_install_status(
                         {

--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ from .core.result_formatter import ResultFormatter
     "astrbot_plugin_web_analyzer",
     "Sakura520222",
     "自动识别网页链接，智能抓取解析内容，集成大语言模型进行深度分析和总结，支持网页截图、缓存机制和多种管理命令",
-    "1.5.5",
+    "1.5.6",
     "https://github.com/Sakura520222/astrbot_plugin_web_analyzer",
 )
 class WebAnalyzerPlugin(Star):

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,7 +3,7 @@ name: astrbot_plugin_web_analyzer
 display_name: 网页分析插件
 author: Sakura520222
 description: 自动识别网页链接，智能抓取解析内容，集成大语言模型进行深度分析和总结，支持网页截图、缓存机制和多种管理命令
-version: 1.5.5
+version: 1.5.6
 repo: https://github.com/Sakura520222/astrbot_plugin_web_analyzer
 support_platforms:
   - aiocqhttp


### PR DESCRIPTION
- 新增 `_detect_system_browser()` 方法，支持 Windows 和 Linux 系统下自动检测已安装的 Chromium 内核浏览器（Chrome > Edge > Chromium）
- 优化浏览器检测逻辑，优先使用系统浏览器，避免下载 Playwright 自带浏览器
- 支持获取并展示检测到的浏览器版本信息
- 更新 `browser_install_status.json` 中 `browser_type` 字段记录实际使用的浏览器名称
- 修复持久化浏览器路径失效时的处理逻辑，确保重新检测流程正常执行
- 更新版本号至 v1.5.6，同步更新 CHANGELOG.md、main.py 和 metadata.yaml